### PR TITLE
Improved FUNC_URI regex so that it works in IE

### DIFF
--- a/src/svgDirs.js
+++ b/src/svgDirs.js
@@ -71,7 +71,7 @@
       };
     }]).
     value('svgAttrExpressions', {
-      FUNC_URI: /^url\((.*)\)$/,
+      FUNC_URI: /^url\(["']*(.*?)["']*\)$/,
       SVG_ELEMENT: /SVG[a-zA-Z]*Element/,
       HASH_PART: /#.*/
     }).


### PR DESCRIPTION
Previously, IE11 (could apply to earlier versions as well, I haven't tested) would include the quotes in the first group returned from the FUNC_URI RegExp, which resulted in URL encoded quotes and breakage where the SVG wouldn't display because there was no such filter. This makes sure the quotes aren't included in the matched group.
